### PR TITLE
fix(ui): handle IME composition across pane focus

### DIFF
--- a/packages/tmuxy-ui/src/components/FloatPane.tsx
+++ b/packages/tmuxy-ui/src/components/FloatPane.tsx
@@ -9,7 +9,7 @@
  * Green border on all sides when active
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Modal } from './Modal';
 import { Terminal } from './Terminal';
 import { PaneHeader } from './PaneHeader';
@@ -22,6 +22,7 @@ import {
 import { LogProfiler } from '../utils/renderLog';
 import type { FloatPaneState } from '../machines/types';
 import type { TmuxPane } from '../machines/types';
+import { focusKeyboardInput, focusMobileInput } from '../utils/mobileKeyboard';
 
 interface FloatPaneProps {
   floatState: FloatPaneState;
@@ -45,15 +46,63 @@ function FloatPaneInner({ floatState, zIndex = 1001 }: FloatPaneProps) {
   const isFocused = focusedFloatPaneId === floatState.paneId;
   const { charHeight } = useAppSelector(selectCharSize);
   const { width: containerWidth, height: containerHeight } = useAppSelector(selectContainerSize);
+  const focusPointerTypeRef = useRef<string | null>(null);
 
   const handleClose = useCallback(() => {
     send({ type: 'CLOSE_FLOAT', paneId: floatState.paneId });
   }, [send, floatState.paneId]);
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    focusPointerTypeRef.current = event.pointerType;
+    if (event.pointerType === 'touch') event.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    const handleWindowPointerUp = (event: PointerEvent) => {
+      const pointerType = event.pointerType;
+      // Keep the modality through the click that browsers dispatch after pointerup.
+      window.setTimeout(() => {
+        if (focusPointerTypeRef.current === pointerType) focusPointerTypeRef.current = null;
+      }, 0);
+    };
+    const handleWindowPointerCancel = () => {
+      focusPointerTypeRef.current = null;
+    };
+
+    window.addEventListener('pointerup', handleWindowPointerUp);
+    window.addEventListener('pointercancel', handleWindowPointerCancel);
+    return () => {
+      window.removeEventListener('pointerup', handleWindowPointerUp);
+      window.removeEventListener('pointercancel', handleWindowPointerCancel);
+    };
+  }, []);
+
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget || focusPointerTypeRef.current !== null) return;
       send({ type: 'FOCUS_PANE', paneId: floatState.paneId });
+      focusKeyboardInput(floatState.paneId);
+    },
+    [send, floatState.paneId],
+  );
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      const pointerType = focusPointerTypeRef.current;
+      focusPointerTypeRef.current = null;
+      const target = event.target as HTMLElement;
+      const shouldFocusKeyboard = !target.closest(
+        'button, input, textarea, select, [contenteditable="true"]',
+      );
+      if (shouldFocusKeyboard && pointerType === 'touch') {
+        focusMobileInput(floatState.paneId);
+      }
+
+      send({ type: 'FOCUS_PANE', paneId: floatState.paneId });
+      if (shouldFocusKeyboard && pointerType !== 'touch') {
+        focusKeyboardInput(floatState.paneId);
+      }
     },
     [send, floatState.paneId],
   );
@@ -105,6 +154,9 @@ function FloatPaneInner({ floatState, zIndex = 1001 }: FloatPaneProps) {
           className="float-content"
           style={{ width: floatWidth, height: terminalHeight }}
           onClick={handleClick}
+          tabIndex={0}
+          onPointerDown={handlePointerDown}
+          onFocus={handleFocus}
         >
           <Terminal
             content={pane.content}
@@ -144,6 +196,8 @@ function FloatPaneInner({ floatState, zIndex = 1001 }: FloatPaneProps) {
     >
       <div
         className="float-container"
+        onPointerDown={handlePointerDown}
+        onFocus={handleFocus}
         onClick={handleClick}
         tabIndex={0}
         data-pane-id={pane.tmuxId}

--- a/packages/tmuxy-ui/src/components/TerminalPane.tsx
+++ b/packages/tmuxy-ui/src/components/TerminalPane.tsx
@@ -30,6 +30,7 @@ import { usePaneMouse, usePaneTouch } from '../hooks';
 import { LogProfiler } from '../utils/renderLog';
 import { isCollapsedPane } from '../constants';
 import { extractSelectedText } from '../utils/copyMode';
+import { focusKeyboardInput } from '../utils/mobileKeyboard';
 
 interface TerminalPaneProps {
   paneId: string;
@@ -46,6 +47,9 @@ export function TerminalPane({ paneId }: TerminalPaneProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const focusPointerTypeRef = useRef<string | null>(null);
+  const mouseFocusHandledRef = useRef(false);
+
   const copyState = useCopyModeState(paneId);
   const { forwardScrollToParent } = useAppConfig();
 
@@ -343,12 +347,42 @@ export function TerminalPane({ paneId }: TerminalPaneProps) {
       data-alternate-on={pane.alternateOn}
       data-mouse-any-flag={pane.mouseAnyFlag}
       tabIndex={0}
+      onPointerDown={(event) => {
+        focusPointerTypeRef.current = event.pointerType;
+        mouseFocusHandledRef.current = false;
+      }}
+      onPointerUp={(event) => {
+        const pointerType = event.pointerType;
+        window.setTimeout(() => {
+          if (focusPointerTypeRef.current === pointerType) {
+            focusPointerTypeRef.current = null;
+            mouseFocusHandledRef.current = false;
+          }
+        }, 0);
+      }}
+      onPointerCancel={() => {
+        focusPointerTypeRef.current = null;
+        mouseFocusHandledRef.current = false;
+      }}
+      onFocus={(event) => {
+        if (event.target !== event.currentTarget) return;
+        const pointerType = focusPointerTypeRef.current;
+        const mouseFocusHandled = mouseFocusHandledRef.current;
+        focusPointerTypeRef.current = null;
+        mouseFocusHandledRef.current = false;
+        if (pointerType === null || (pointerType !== 'touch' && !mouseFocusHandled)) {
+          send({ type: 'FOCUS_PANE', paneId });
+        }
+        if (pointerType !== 'touch') focusKeyboardInput(paneId);
+      }}
       onMouseDown={(e) => {
         if (e.detail >= 3 && e.button === 0) {
           handleTripleClick(e);
           return;
         }
+        const mouseFocusHandled = !(e.target as HTMLElement).closest('.pane-header');
         handleMouseDown(e);
+        mouseFocusHandledRef.current = mouseFocusHandled;
       }}
       onMouseUp={handleMouseUp}
       onMouseMove={handleMouseMove}

--- a/packages/tmuxy-ui/src/hooks/__tests__/usePaneTouch.test.tsx
+++ b/packages/tmuxy-ui/src/hooks/__tests__/usePaneTouch.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppMachineEvent } from '../../machines/types';
+
+vi.mock('../../utils/mobileKeyboard', () => ({
+  focusMobileInput: vi.fn(),
+}));
+vi.mock('../../utils/haptics', () => ({
+  haptics: { trigger: vi.fn() },
+}));
+
+import { focusMobileInput } from '../../utils/mobileKeyboard';
+import { usePaneTouch } from '../usePaneTouch';
+
+const mockFocusMobileInput = vi.mocked(focusMobileInput);
+
+function touchEvent(type: 'touchstart' | 'touchend', x: number, y: number): TouchEvent {
+  const touch = { clientX: x, clientY: y };
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    touches: { value: type === 'touchstart' ? [touch] : [] },
+    changedTouches: { value: type === 'touchend' ? [touch] : [] },
+  });
+  return event as TouchEvent;
+}
+
+describe('usePaneTouch tap focus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('switches the keyboard target before synchronizing pane focus', () => {
+    const send = vi.fn<(event: AppMachineEvent) => void>();
+    const scrollRef = createRef<HTMLDivElement>();
+    scrollRef.current = document.createElement('div');
+    const { result } = renderHook(() =>
+      usePaneTouch({
+        paneId: '%9',
+        charHeight: 18,
+        alternateOn: false,
+        mouseAnyFlag: false,
+        scrollRef,
+        send,
+        historySize: 0,
+      }),
+    );
+    const start = touchEvent('touchstart', 10, 20);
+    const end = touchEvent('touchend', 12, 22);
+
+    act(() => {
+      result.current.handleTouchStart(start);
+      result.current.handleTouchEnd(end);
+    });
+
+    expect(end.defaultPrevented).toBe(true);
+    expect(mockFocusMobileInput).toHaveBeenCalledWith('%9');
+    expect(send).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%9' });
+    expect(mockFocusMobileInput.mock.invocationCallOrder[0]).toBeLessThan(
+      send.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/packages/tmuxy-ui/src/hooks/usePaneTouch.ts
+++ b/packages/tmuxy-ui/src/hooks/usePaneTouch.ts
@@ -158,8 +158,8 @@ export function usePaneTouch(options: UsePaneTouchOptions) {
           // which steals focus from the hidden mobile input and closes the keyboard.
           e.preventDefault();
           haptics.trigger(10);
-          send({ type: 'FOCUS_PANE', paneId });
           focusMobileInput(paneId);
+          send({ type: 'FOCUS_PANE', paneId });
         }
       }
       tapStartRef.current = null;

--- a/packages/tmuxy-ui/src/machines/actors/__tests__/keyboardActor.test.ts
+++ b/packages/tmuxy-ui/src/machines/actors/__tests__/keyboardActor.test.ts
@@ -1,14 +1,23 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createActor, createMachine, type AnyActorRef } from 'xstate';
 import { createKeyboardActor } from '../keyboardActor';
+import * as mobileKeyboard from '../../../utils/mobileKeyboard';
+
+type RecordedEvent = { type: string; [key: string]: unknown };
+
+interface KeyboardActorHandle {
+  actor: AnyActorRef;
+  child: AnyActorRef;
+  events: RecordedEvent[];
+}
 
 /**
  * Spawn the keyboard actor under a tiny parent that records every event it
  * sends and exposes a context snapshot (the actor reads activePaneId /
  * copyModeStates off the parent snapshot for copy-mode detection).
  */
-function spawnKeyboardActor(activePaneId = '%3') {
-  const events: Array<{ type: string; [k: string]: unknown }> = [];
+function spawnKeyboardActor(activePaneId = '%3'): KeyboardActorHandle {
+  const events: RecordedEvent[] = [];
   const keyboardActor = createKeyboardActor();
   const parent = createMachine({
     types: {} as {
@@ -41,17 +50,422 @@ function pressKey(init: KeyboardEventInit) {
   window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
 }
 
-function lastSendCommand(
-  events: Array<{ type: string; [k: string]: unknown }>,
-): string | undefined {
+function lastSendCommand(events: RecordedEvent[]): string | undefined {
   for (let i = events.length - 1; i >= 0; i--) {
     if (events[i].type === 'SEND_TMUX_COMMAND') return events[i].command as string;
   }
   return undefined;
 }
 
+function sendCommands(events: RecordedEvent[]): string[] {
+  return events
+    .filter((event) => event.type === 'SEND_TMUX_COMMAND')
+    .map((event) => event.command as string);
+}
+
+function startComposition(input: HTMLInputElement, texts: string[]) {
+  input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  for (const text of texts) {
+    input.value = text;
+    input.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        data: text,
+        inputType: 'insertCompositionText',
+        isComposing: true,
+      }),
+    );
+  }
+}
+
+function commitComposition(input: HTMLInputElement, text: string) {
+  input.value = text;
+  input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: text }));
+  input.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      data: text,
+      inputType: 'insertText',
+      isComposing: false,
+    }),
+  );
+}
+
+function insertText(input: HTMLInputElement, text: string) {
+  input.value = text;
+  input.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      data: text,
+      inputType: 'insertText',
+    }),
+  );
+}
+
+function pasteText(text: string) {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+  });
+  window.dispatchEvent(event);
+}
+
+describe('keyboardActor — desktop IME', () => {
+  let handle: KeyboardActorHandle;
+
+  beforeEach(() => {
+    delete (window as Window & { ontouchstart?: unknown }).ontouchstart;
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 0 });
+    handle = spawnKeyboardActor('%3');
+  });
+
+  afterEach(() => {
+    handle.actor.stop();
+    const input = mobileKeyboard.getMobileInput();
+    if (input) {
+      input.value = '';
+      input.blur();
+    }
+  });
+
+  it('installs an editable input in a non-touch browser', () => {
+    const input = mobileKeyboard.getMobileInput();
+
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input?.isConnected).toBe(true);
+  });
+
+  it('focuses the editable input when the first active pane arrives', () => {
+    const input = mobileKeyboard.getMobileInput();
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('does not steal initial focus from a real form control', () => {
+    handle.actor.stop();
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    handle = spawnKeyboardActor('%4');
+
+    expect(document.activeElement).toBe(textarea);
+    textarea.remove();
+  });
+
+  it('leaves composition from a real form control in the browser', () => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    handle.events.length = 0;
+
+    textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    textarea.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '한글' }));
+    pressKey({ key: 'x' });
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l 'x'"]);
+    textarea.remove();
+  });
+
+  it('waits for a user gesture before focusing on a touch device', () => {
+    handle.actor.stop();
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    input.blur();
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 });
+
+    handle = spawnKeyboardActor('%3');
+
+    expect(document.activeElement).not.toBe(input);
+    mobileKeyboard.focusMobileInput('%3');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('supports mouse or keyboard focus on a touch-capable hybrid device', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 });
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+
+    mobileKeyboard.focusKeyboardInput('%3');
+    expect(document.activeElement).toBe(input);
+
+    input.blur();
+    mobileKeyboard.focusMobileInput('%3');
+    expect(document.activeElement).toBe(input);
+
+    mobileKeyboard.focusMobileInput('%3');
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it('forwards ordinary desktop text exactly once through the hidden input', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'a' }));
+    input.value = 'a';
+    input.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        data: 'a',
+        inputType: 'insertText',
+      }),
+    );
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l 'a'"]);
+  });
+
+  it('routes hidden-input text to an active pane selected after focus moved', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    mobileKeyboard.focusKeyboardInput('%3');
+
+    handle.child.send({ type: 'UPDATE_ACTIVE_PANE', paneId: '%4' });
+    insertText(input, 'b');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %4 -l 'b'"]);
+  });
+
+  it('routes hidden-input text to a newly focused float pane', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    mobileKeyboard.focusKeyboardInput('%3');
+
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: '%9' });
+    insertText(input, 'f');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %9 -l 'f'"]);
+  });
+
+  it('returns hidden-input text to the active pane after a float loses focus', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: '%9' });
+    mobileKeyboard.focusKeyboardInput('%9');
+
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: null });
+    insertText(input, 'r');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l 'r'"]);
+  });
+
+  it('keeps printable prefix bindings active while the hidden input owns focus', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    handle.child.send({
+      type: 'UPDATE_KEYBINDINGS',
+      keybindings: {
+        prefix_key: 'C-a',
+        prefix_bindings: [{ key: 'c', command: 'new-window', description: 'new window' }],
+        root_bindings: [],
+      },
+    });
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'a', ctrlKey: true }),
+    );
+    const bindingKey = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'c',
+    });
+    input.dispatchEvent(bindingKey);
+
+    expect(bindingKey.defaultPrevented).toBe(true);
+    expect(sendCommands(handle.events)).toEqual(['select-pane -t %3 \\; new-window']);
+  });
+
+  it('keeps printable root bindings active while the hidden input owns focus', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    handle.child.send({
+      type: 'UPDATE_KEYBINDINGS',
+      keybindings: {
+        prefix_key: 'C-a',
+        prefix_bindings: [],
+        root_bindings: [{ key: 'c', command: 'display-message root', description: 'root' }],
+      },
+    });
+
+    const rootKey = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'c',
+    });
+    input.dispatchEvent(rootKey);
+
+    expect(rootKey.defaultPrevented).toBe(true);
+    expect(sendCommands(handle.events)).toEqual(['select-pane -t %3 \\; display-message root']);
+  });
+
+  it('cancels a printable prefix key before the hidden input emits text', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    handle.child.send({
+      type: 'UPDATE_KEYBINDINGS',
+      keybindings: {
+        prefix_key: 'a',
+        prefix_bindings: [],
+        root_bindings: [],
+      },
+    });
+
+    const prefix = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'a',
+    });
+    input.dispatchEvent(prefix);
+    if (!prefix.defaultPrevented) insertText(input, 'a');
+
+    expect(prefix.defaultPrevented).toBe(true);
+    expect(handle.events).toContainEqual({ type: 'PREFIX_MODE_CHANGE', active: true });
+    expect(sendCommands(handle.events)).toEqual([]);
+  });
+
+  it('keeps the buffer intact while multiple jamo are composing', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+
+    startComposition(input, ['ㅎ', '하', '한']);
+
+    expect(input.value).toBe('한');
+    expect(sendCommands(handle.events)).toEqual([]);
+  });
+
+  it('forwards committed Hangul exactly once', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    mobileKeyboard.focusKeyboardInput('%3');
+
+    startComposition(input, ['ㅎ']);
+    commitComposition(input, '한글');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l '한글'"]);
+  });
+
+  it('commits hidden-input composition to the pane where composition started', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    mobileKeyboard.focusKeyboardInput('%3');
+    startComposition(input, ['ㅎ']);
+
+    handle.child.send({ type: 'UPDATE_ACTIVE_PANE', paneId: '%4' });
+    mobileKeyboard.focusKeyboardInput('%4');
+    commitComposition(input, '한');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l '한'"]);
+  });
+
+  it('pins hidden-input composition to the actor target at composition start', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    mobileKeyboard.focusKeyboardInput('%3');
+    handle.child.send({ type: 'UPDATE_ACTIVE_PANE', paneId: '%4' });
+    startComposition(input, ['ㅎ']);
+
+    handle.child.send({ type: 'UPDATE_ACTIVE_PANE', paneId: '%5' });
+    commitComposition(input, '한');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %4 -l '한'"]);
+  });
+
+  it('commits non-input composition to the pane where composition started', () => {
+    window.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    handle.child.send({ type: 'UPDATE_ACTIVE_PANE', paneId: '%4' });
+    window.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '한' }));
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %3 -l '한'"]);
+  });
+
+  it('forwards committed Hangul to the focused float pane', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: '%9' });
+    mobileKeyboard.focusKeyboardInput('%9');
+
+    startComposition(input, ['ㅎ']);
+    commitComposition(input, '한');
+
+    expect(sendCommands(handle.events)).toEqual(["send-keys -t %9 -l '한'"]);
+  });
+
+  it('drops a composition commit after keyboard forwarding is disabled', () => {
+    window.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    handle.child.send({ type: 'UPDATE_ENABLED', enabled: false });
+    window.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '한' }));
+
+    expect(sendCommands(handle.events)).toEqual([]);
+  });
+
+  it('falls back to the session for text, special keys, composition, and paste while a float is provisional', () => {
+    const input = mobileKeyboard.getMobileInput();
+    expect(input).not.toBeNull();
+    if (!input) return;
+    const placeholder = '__placeholder_float_1';
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: placeholder });
+
+    insertText(input, 'x');
+    pressKey({ key: 'Tab' });
+    startComposition(input, ['ㅎ']);
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: '%9' });
+    commitComposition(input, '한');
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: placeholder });
+    pasteText('붙여넣기');
+
+    expect(sendCommands(handle.events)).toEqual([
+      "send-keys -t tmuxy -l 'x'",
+      'send-keys -t tmuxy Tab',
+      "send-keys -t tmuxy -l '한'",
+      "send-keys -t tmuxy -l '붙여넣기'",
+    ]);
+    expect(sendCommands(handle.events).join('\n')).not.toContain(placeholder);
+  });
+
+  it('never pins prefix or root commands to a provisional float id', () => {
+    const placeholder = '__placeholder_float_1';
+    handle.child.send({ type: 'UPDATE_FOCUSED_FLOAT', paneId: placeholder });
+    handle.child.send({
+      type: 'UPDATE_KEYBINDINGS',
+      keybindings: {
+        prefix_key: 'C-a',
+        prefix_bindings: [{ key: 'c', command: 'new-window', description: 'new window' }],
+        root_bindings: [
+          { key: 'F2', command: 'display-message root', description: 'root binding' },
+        ],
+      },
+    });
+
+    pressKey({ key: 'a', ctrlKey: true });
+    pressKey({ key: 'c' });
+    pressKey({ key: 'F2' });
+    pressKey({ key: 'a', ctrlKey: true });
+    pressKey({ key: 'a', ctrlKey: true });
+
+    expect(sendCommands(handle.events)).toEqual([
+      'new-window',
+      'display-message root',
+      'send-keys -t tmuxy C-a',
+    ]);
+    expect(sendCommands(handle.events).join('\n')).not.toContain(placeholder);
+  });
+});
+
 describe('keyboardActor — Tab / Shift-Tab', () => {
-  let handle: ReturnType<typeof spawnKeyboardActor>;
+  let handle: KeyboardActorHandle;
   beforeEach(() => {
     handle = spawnKeyboardActor('%3');
   });

--- a/packages/tmuxy-ui/src/machines/actors/keyboardActor.ts
+++ b/packages/tmuxy-ui/src/machines/actors/keyboardActor.ts
@@ -15,7 +15,13 @@
 import { fromCallback, type AnyActorRef } from 'xstate';
 import type { KeyBindings, CopyModeState } from '../../tmux/types';
 import { extractSelectedText } from '../../utils/copyMode';
-import { setupMobileKeyboard, getMobileInput, isTouchDevice } from '../../utils/mobileKeyboard';
+import {
+  focusKeyboardInput,
+  getMobileInput,
+  isTouchDevice,
+  setKeyboardInputTarget,
+  setupMobileKeyboard,
+} from '../../utils/mobileKeyboard';
 
 export type KeyboardActorEvent =
   | { type: 'UPDATE_SESSION'; sessionName: string }
@@ -135,6 +141,8 @@ export function createKeyboardActor() {
     let sidebarFocused = false;
     let enabled = true;
     let isComposing = false;
+    let compositionTarget: string | null = null;
+    let keyboardFocusEstablished = false;
     // Text pending copy via native clipboard event (client-side copy mode yank)
     let pendingCopyText: string | null = null;
     let inPrefixMode = false;
@@ -146,25 +154,61 @@ export function createKeyboardActor() {
     let prefixRepeatKeys: Set<string> = new Set();
     let rootBindings: Map<string, string> = new Map();
 
+    const currentRealPaneTarget = (): string | null => {
+      if (focusedFloatPaneId !== null) return realPaneId(focusedFloatPaneId);
+      return realPaneId(activePaneId);
+    };
+
+    const currentPaneTarget = (): string => currentRealPaneTarget() ?? sessionName;
+
+    const isRealFormControl = (target: EventTarget | null): boolean => {
+      const element = target as HTMLElement | null;
+      return (
+        element !== null &&
+        (element.tagName === 'TEXTAREA' || element.tagName === 'INPUT') &&
+        element !== getMobileInput()
+      );
+    };
+
+    const syncKeyboardInputTarget = () => {
+      const paneId = focusedFloatPaneId ?? activePaneId;
+      setKeyboardInputTarget(paneId);
+
+      if (document.activeElement === getMobileInput()) {
+        keyboardFocusEstablished = true;
+        return;
+      }
+
+      const realTarget = currentRealPaneTarget();
+      if (
+        !isTouchDevice() &&
+        !keyboardFocusEstablished &&
+        realTarget !== null &&
+        document.activeElement === document.body
+      ) {
+        // IME composition cannot start until an editable element owns browser focus.
+        focusKeyboardInput(realTarget);
+        keyboardFocusEstablished = true;
+      }
+    };
+
     // Prefix key timeout (tmux default is 500ms, we use 8000ms so the hint is
     // readable and users have time to choose a binding)
     const PREFIX_TIMEOUT_MS = 8000;
 
-    // Mobile keyboard: forward typed characters to the active tmux session.
-    // keydown handles special keys (Backspace, Enter, arrows) via the existing
-    // window listener; this handles printable chars that mobile browsers only
-    // deliver via `input` events.
-    const cleanupMobileKeyboard = isTouchDevice()
-      ? setupMobileKeyboard((text) => {
-          if (!enabled) return;
-          const escaped = escapeLiteralText(text);
-          const mobileTarget = focusedFloatPaneId ?? realPaneId(activePaneId) ?? sessionName;
-          input.parent.send({
-            type: 'SEND_TMUX_COMMAND',
-            command: `send-keys -t ${mobileTarget} -l ${escaped}`,
-          });
-        })
-      : null;
+    // The hidden editable input is required on desktop for IME composition and
+    // on touch devices for virtual-keyboard text events. Special keys still
+    // travel through the window keydown listener.
+    const cleanupKeyboardInput = setupMobileKeyboard((text, paneId) => {
+      if (!enabled) return;
+      const escaped = escapeLiteralText(text);
+      const textTarget =
+        paneId === null ? currentPaneTarget() : (realPaneId(paneId) ?? sessionName);
+      input.parent.send({
+        type: 'SEND_TMUX_COMMAND',
+        command: `send-keys -t ${textTarget} -l ${escaped}`,
+      });
+    });
 
     const resetPrefixMode = (notify = true) => {
       const wasActive = inPrefixMode;
@@ -196,16 +240,9 @@ export function createKeyboardActor() {
       // control (e.g. the read-only debug log textarea on the status screen).
       // Without this, keys like Cmd+A / Cmd+C wouldn't reach the textarea
       // because they'd be intercepted as send-keys / copy-mode triggers.
-      // Mobile keyboard's hidden input is excluded — it has dedicated handling
-      // further down (mobileKeyboard.ts forwards `input` events).
-      const eventTarget = event.target as HTMLElement | null;
-      if (
-        eventTarget &&
-        (eventTarget.tagName === 'TEXTAREA' || eventTarget.tagName === 'INPUT') &&
-        eventTarget !== getMobileInput()
-      ) {
-        return;
-      }
+      // The shared hidden keyboard input is excluded because mobileKeyboard.ts
+      // forwards its `input` events through the dedicated text path below.
+      if (isRealFormControl(event.target)) return;
 
       // Skip during IME composition
       // keyCode 229 is a special value indicating IME is processing
@@ -308,19 +345,17 @@ export function createKeyboardActor() {
         return;
       }
 
-      // On mobile, printable character keydowns from the hidden input are handled
-      // by the `input` event in mobileKeyboard.ts to avoid double-sending.
-      if (
+      // Printable keydowns from the hidden input normally become `input`
+      // events. Keep evaluating them long enough for prefix and root bindings
+      // to win; only the unbound path should fall through to text input.
+      const hiddenInputPrintable =
         event.target === getMobileInput() &&
         event.key.length === 1 &&
         !event.ctrlKey &&
         !event.altKey &&
-        !event.metaKey
-      ) {
-        return;
-      }
+        !event.metaKey;
 
-      event.preventDefault();
+      if (!hiddenInputPrintable) event.preventDefault();
 
       // Escape returns focus from the sidebar to the panes (the drawer stays
       // open; the tree window is hidden, not killed).
@@ -343,10 +378,11 @@ export function createKeyboardActor() {
       // would trigger the "double prefix" handler, resetting prefix mode
       // before the user can press the binding key.
       if (formattedKey === prefixKey && !event.repeat) {
+        event.preventDefault();
         if (inPrefixMode) {
           // Double prefix sends literal prefix key to the shell
           resetPrefixMode();
-          const prefixTarget = focusedFloatPaneId ?? realPaneId(activePaneId) ?? sessionName;
+          const prefixTarget = currentPaneTarget();
           input.parent.send({
             type: 'SEND_TMUX_COMMAND',
             command: `send-keys -t ${prefixTarget} ${prefixKey}`,
@@ -369,6 +405,7 @@ export function createKeyboardActor() {
 
       // If in prefix mode, look up the binding
       if (inPrefixMode) {
+        event.preventDefault();
         // Clear the current prefix timeout but don't notify yet —
         // we may re-enter prefix mode below for repeat bindings.
         if (prefixTimeout) {
@@ -424,7 +461,7 @@ export function createKeyboardActor() {
           // aligns tmux's view with ours before the binding executes; for
           // bindings that carry their own target (e.g., `select-pane -L`), the
           // prepend is a harmless no-op since the binding overrides it.
-          const target = focusedFloatPaneId ?? realPaneId(activePaneId);
+          const target = currentRealPaneTarget();
           const command = target
             ? `select-pane -t ${target} \\; ${bindingCommand}`
             : bindingCommand;
@@ -471,10 +508,11 @@ export function createKeyboardActor() {
 
       const rootCommand = rootBindings.get(formattedKey);
       if (rootCommand) {
+        event.preventDefault();
         // Same prefix-pin treatment as prefix bindings — root bindings (bind -n)
         // also run against tmux's server-side active pane and need the
         // post-tab-switch / post-group-swap race guarded the same way.
-        const target = focusedFloatPaneId ?? realPaneId(activePaneId);
+        const target = currentRealPaneTarget();
         const command = target ? `select-pane -t ${target} \\; ${rootCommand}` : rootCommand;
         input.parent.send({
           type: 'SEND_TMUX_COMMAND',
@@ -492,11 +530,13 @@ export function createKeyboardActor() {
         return;
       }
 
+      if (hiddenInputPrintable) return;
+
       // Normal key handling - send via send-keys
       // Target priority: focused float > active pane ID > session name
       // Using activePaneId ensures input reaches the correct pane immediately
       // after an optimistic tab switch (before tmux processes select-window).
-      const target = focusedFloatPaneId ?? realPaneId(activePaneId) ?? sessionName;
+      const target = currentPaneTarget();
       // Use literal mode (-l) for single printable chars to avoid tmux syntax interpretation
       let command: string;
       if (event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
@@ -520,21 +560,37 @@ export function createKeyboardActor() {
       });
     };
 
-    const handleCompositionStart = () => {
+    const handleCompositionStart = (event: CompositionEvent) => {
+      if (isRealFormControl(event.target)) {
+        isComposing = false;
+        compositionTarget = null;
+        return;
+      }
       isComposing = true;
+      compositionTarget = currentPaneTarget();
     };
 
     const handleCompositionEnd = (event: CompositionEvent) => {
+      if (isRealFormControl(event.target)) {
+        isComposing = false;
+        compositionTarget = null;
+        return;
+      }
       isComposing = false;
+      const target = compositionTarget ?? currentPaneTarget();
+      compositionTarget = null;
+      if (!enabled) return;
 
-      // Send the composed text as a literal string
+      // The hidden input owns its commit so its following input event can be
+      // de-duplicated. Composition from any other target stays on this path.
+      if (event.target === getMobileInput()) return;
+
       const composedText = event.data;
       if (composedText) {
-        // Use -l flag for literal text to avoid key interpretation
         const escaped = escapeLiteralText(composedText);
         input.parent.send({
           type: 'SEND_TMUX_COMMAND',
-          command: `send-keys -t ${realPaneId(activePaneId) ?? sessionName} -l ${escaped}`,
+          command: `send-keys -t ${target} -l ${escaped}`,
         });
       }
     };
@@ -553,7 +609,7 @@ export function createKeyboardActor() {
       const lines = text.split('\n');
       const commands: string[] = [];
 
-      const pasteTarget = focusedFloatPaneId ?? realPaneId(activePaneId) ?? sessionName;
+      const pasteTarget = currentPaneTarget();
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         if (line.length > 0) {
@@ -599,6 +655,7 @@ export function createKeyboardActor() {
         sessionName = event.sessionName;
       } else if (event.type === 'UPDATE_ACTIVE_PANE') {
         activePaneId = event.paneId;
+        syncKeyboardInputTarget();
       } else if (event.type === 'UPDATE_KEYBINDINGS') {
         const kb = event.keybindings;
         prefixKey = kb.prefix_key;
@@ -609,13 +666,14 @@ export function createKeyboardActor() {
         enabled = event.enabled;
       } else if (event.type === 'UPDATE_FOCUSED_FLOAT') {
         focusedFloatPaneId = event.paneId;
+        syncKeyboardInputTarget();
       } else if (event.type === 'UPDATE_SIDEBAR_FOCUSED') {
         sidebarFocused = event.focused;
       }
     });
 
     return () => {
-      cleanupMobileKeyboard?.();
+      cleanupKeyboardInput();
       resetPrefixMode(false);
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('compositionstart', handleCompositionStart);

--- a/packages/tmuxy-ui/src/test/FloatPane.test.tsx
+++ b/packages/tmuxy-ui/src/test/FloatPane.test.tsx
@@ -1,0 +1,195 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { ReactNode } from 'react';
+import type { AppMachineEvent, FloatPaneState } from '../machines/types';
+
+vi.mock('../machines/AppContext', () => ({
+  useAppSend: vi.fn(),
+  useAppSelector: vi.fn(),
+  selectCharSize: vi.fn(),
+  selectContainerSize: vi.fn(),
+}));
+vi.mock('../components/Modal', () => ({
+  Modal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../components/Terminal', () => ({
+  Terminal: () => <div data-testid="terminal" />,
+}));
+vi.mock('../components/PaneHeader', () => ({
+  PaneHeader: () => <div data-testid="pane-header" />,
+}));
+vi.mock('../utils/renderLog', () => ({
+  LogProfiler: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../utils/mobileKeyboard', () => ({
+  focusKeyboardInput: vi.fn(),
+  focusMobileInput: vi.fn(),
+}));
+
+import * as AppContext from '../machines/AppContext';
+import { FloatPane } from '../components/FloatPane';
+import * as mobileKeyboard from '../utils/mobileKeyboard';
+
+const mockUseAppSend = AppContext.useAppSend as Mock;
+const mockUseAppSelector = AppContext.useAppSelector as Mock;
+const mockSelectCharSize = AppContext.selectCharSize as Mock;
+const mockSelectContainerSize = AppContext.selectContainerSize as Mock;
+const mockFocusKeyboardInput = vi.mocked(mobileKeyboard.focusKeyboardInput);
+const mockFocusMobileInput = vi.mocked(mobileKeyboard.focusMobileInput);
+const mockSend = vi.fn<(event: AppMachineEvent) => void>();
+
+const pane = {
+  id: 9,
+  tmuxId: '%9',
+  windowId: '@1',
+  content: { lines: [] },
+  cursorX: 0,
+  cursorY: 0,
+  width: 80,
+  height: 24,
+  x: 0,
+  y: 0,
+  active: true,
+  command: 'zsh',
+  title: '',
+  borderTitle: '',
+  inMode: false,
+  copyCursorX: 0,
+  copyCursorY: 0,
+  alternateOn: false,
+  mouseAnyFlag: false,
+  paused: false,
+  historySize: 0,
+  selectionPresent: false,
+  selectionStartX: 0,
+  selectionStartY: 0,
+  cursorShape: 2,
+  cursorHidden: false,
+};
+
+const context = {
+  panes: [pane],
+  focusedFloatPaneId: null,
+};
+
+const floatState: FloatPaneState = {
+  paneId: '%9',
+  width: 640,
+  height: 360,
+  hideHeader: true,
+};
+
+function renderFloat() {
+  const rendered = render(<FloatPane floatState={floatState} />);
+  const container = rendered.container.querySelector<HTMLElement>('[data-pane-id="%9"]');
+  expect(container).not.toBeNull();
+  if (!container) throw new Error('float pane container missing');
+  return container;
+}
+
+describe('FloatPane keyboard focus', () => {
+  let hiddenInput: HTMLInputElement;
+  let keyboardTarget: string | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    hiddenInput = document.createElement('input');
+    document.body.appendChild(hiddenInput);
+    keyboardTarget = null;
+
+    mockUseAppSend.mockReturnValue(mockSend);
+    mockUseAppSelector.mockImplementation((selector: (value: typeof context) => unknown) => {
+      if (selector === mockSelectCharSize) return { charWidth: 8, charHeight: 18 };
+      if (selector === mockSelectContainerSize) return { width: 1200, height: 800 };
+      return selector(context);
+    });
+    mockSend.mockImplementation((event) => {
+      if (event.type === 'FOCUS_PANE') keyboardTarget = event.paneId;
+    });
+    mockFocusKeyboardInput.mockImplementation((paneId) => {
+      keyboardTarget = paneId;
+      hiddenInput.focus();
+    });
+    mockFocusMobileInput.mockImplementation((paneId) => {
+      const isOpen = document.activeElement === hiddenInput;
+      if (isOpen && keyboardTarget === paneId) {
+        hiddenInput.blur();
+        keyboardTarget = null;
+      } else {
+        keyboardTarget = paneId;
+        hiddenInput.focus();
+      }
+    });
+  });
+
+  afterEach(() => {
+    hiddenInput.remove();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('selects the pane before moving programmatic focus to the hidden input', () => {
+    const container = renderFloat();
+
+    container.focus();
+
+    expect(mockSend).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%9' });
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%9');
+    expect(mockSend.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFocusKeyboardInput.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not repeat pane selection when focus follows a mouse press', () => {
+    const container = renderFloat();
+
+    fireEvent.pointerDown(container, { pointerType: 'mouse' });
+    container.focus();
+    fireEvent.click(container);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%9');
+  });
+
+  it('prevents browser focus theft and dismisses an open keyboard on a same-pane touch', () => {
+    const container = renderFloat();
+    keyboardTarget = '%9';
+    hiddenInput.focus();
+
+    const defaultAllowed = fireEvent.pointerDown(container, { pointerType: 'touch' });
+    fireEvent.click(container);
+
+    expect(defaultAllowed).toBe(false);
+    expect(mockFocusMobileInput).toHaveBeenCalledWith('%9');
+    expect(document.activeElement).not.toBe(hiddenInput);
+  });
+
+  it('keeps an open keyboard active when touch switches from another pane', () => {
+    const container = renderFloat();
+    keyboardTarget = '%3';
+    hiddenInput.focus();
+
+    fireEvent.pointerDown(container, { pointerType: 'touch' });
+    fireEvent.click(container);
+
+    expect(document.activeElement).toBe(hiddenInput);
+    expect(keyboardTarget).toBe('%9');
+    expect(mockFocusMobileInput.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSend.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('clears pointer modality when a mouse press ends outside the float', () => {
+    const container = renderFloat();
+    fireEvent.pointerDown(container, { pointerType: 'mouse' });
+
+    fireEvent.pointerUp(window, { pointerType: 'mouse' });
+    act(() => vi.runOnlyPendingTimers());
+    container.focus();
+
+    expect(mockSend).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%9' });
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%9');
+  });
+});

--- a/packages/tmuxy-ui/src/test/TerminalPaneCollapsed.test.tsx
+++ b/packages/tmuxy-ui/src/test/TerminalPaneCollapsed.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import type { Mock } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 // Mock AppContext hooks before importing the component under test.
 vi.mock('../machines/AppContext', () => ({
@@ -22,10 +23,13 @@ vi.mock('../components/ScrollbackTerminal', () => ({
   ScrollbackTerminal: () => <div data-testid="scrollback" />,
 }));
 vi.mock('../components/PaneHeader', () => ({
-  PaneHeader: () => <div data-testid="pane-header" />,
+  PaneHeader: () => <div className="pane-header" data-testid="pane-header" />,
 }));
 vi.mock('../components/SelectionContextMenu', () => ({
   SelectionContextMenu: () => <div data-testid="selection-menu" />,
+}));
+vi.mock('../utils/mobileKeyboard', () => ({
+  focusKeyboardInput: vi.fn(),
 }));
 
 const noopHandlers = {
@@ -49,10 +53,14 @@ vi.mock('../hooks', () => ({
 
 import * as AppContext from '../machines/AppContext';
 import { TerminalPane } from '../components/TerminalPane';
+import * as mobileKeyboard from '../utils/mobileKeyboard';
 
-const mockUsePane = AppContext.usePane as ReturnType<typeof vi.fn>;
-const mockUseAppSelector = AppContext.useAppSelector as ReturnType<typeof vi.fn>;
-const mockSelectCharSize = AppContext.selectCharSize as ReturnType<typeof vi.fn>;
+const mockUseAppSend = AppContext.useAppSend as Mock;
+const mockUsePane = AppContext.usePane as Mock;
+const mockUseAppSelector = AppContext.useAppSelector as Mock;
+const mockSelectCharSize = AppContext.selectCharSize as Mock;
+const mockFocusKeyboardInput = vi.mocked(mobileKeyboard.focusKeyboardInput);
+const mockSend = vi.fn();
 
 function makePane(overrides: Record<string, unknown>) {
   return {
@@ -89,6 +97,7 @@ function makePane(overrides: Record<string, unknown>) {
 describe('TerminalPane — collapsed (stacked) pane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAppSend.mockReturnValue(mockSend);
     const ctx = { charWidth: 9.6, charHeight: 21, focusedFloatPaneId: null };
     mockSelectCharSize.mockImplementation(() => ({ charWidth: 9.6, charHeight: 21 }));
     mockUseAppSelector.mockImplementation((sel: (c: typeof ctx) => unknown) => sel(ctx));
@@ -99,6 +108,79 @@ describe('TerminalPane — collapsed (stacked) pane', () => {
     render(<TerminalPane paneId="%1" />);
     expect(screen.getByTestId('pane-header')).toBeInTheDocument();
     expect(screen.getByTestId('terminal-content')).toBeInTheDocument();
+  });
+
+  it('syncs the active pane before moving keyboard focus to the hidden input', () => {
+    mockUsePane.mockReturnValue(makePane({ height: 24 }));
+    render(<TerminalPane paneId="%1" />);
+
+    screen.getByRole('group', { name: 'Pane %1: zsh' }).focus();
+
+    expect(mockSend).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%1' });
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%1');
+    expect(mockSend.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFocusKeyboardInput.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('leaves touch-origin focus to the touch handler', () => {
+    mockUsePane.mockReturnValue(makePane({ height: 24 }));
+    render(<TerminalPane paneId="%1" />);
+    const pane = screen.getByRole('group', { name: 'Pane %1: zsh' });
+
+    fireEvent.pointerDown(pane, { pointerType: 'touch' });
+    pane.focus();
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockFocusKeyboardInput).not.toHaveBeenCalled();
+  });
+
+  it('does not repeat pane selection when focus follows mouse down', () => {
+    mockUsePane.mockReturnValue(makePane({ height: 24 }));
+    noopHandlers.handleMouseDown.mockImplementationOnce(() => {
+      mockSend({ type: 'FOCUS_PANE', paneId: '%1' });
+    });
+    render(<TerminalPane paneId="%1" />);
+    const pane = screen.getByRole('group', { name: 'Pane %1: zsh' });
+
+    fireEvent.pointerDown(pane, { pointerType: 'mouse' });
+    fireEvent.mouseDown(pane);
+    pane.focus();
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%1');
+  });
+
+  it('focuses a header-clicked pane before moving keyboard input to it', () => {
+    mockUsePane.mockReturnValue(makePane({ height: 24 }));
+    render(<TerminalPane paneId="%1" />);
+    const pane = screen.getByRole('group', { name: 'Pane %1: zsh' });
+
+    fireEvent.pointerDown(screen.getByTestId('pane-header'), { pointerType: 'mouse' });
+    fireEvent.mouseDown(screen.getByTestId('pane-header'));
+    pane.focus();
+
+    expect(mockSend).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%1' });
+    expect(mockFocusKeyboardInput).toHaveBeenCalledWith('%1');
+    expect(mockSend.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFocusKeyboardInput.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('focuses a pane when the initial mouse down is a triple click', () => {
+    mockUsePane.mockReturnValue(makePane({ height: 24 }));
+    render(<TerminalPane paneId="%1" />);
+    const pane = screen.getByRole('group', { name: 'Pane %1: zsh' });
+
+    fireEvent.pointerDown(pane, { pointerType: 'mouse' });
+    fireEvent.mouseDown(pane, { detail: 3, button: 0 });
+    pane.focus();
+
+    expect(noopHandlers.handleTripleClick).toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledWith({ type: 'FOCUS_PANE', paneId: '%1' });
+    expect(mockSend.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFocusKeyboardInput.mock.invocationCallOrder[0],
+    );
   });
 
   it('hides terminal content for a collapsed pane (height === 1), keeping the header', () => {

--- a/packages/tmuxy-ui/src/utils/__tests__/mobileKeyboard.test.ts
+++ b/packages/tmuxy-ui/src/utils/__tests__/mobileKeyboard.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  focusKeyboardInput,
+  getMobileInput,
+  setKeyboardInputTarget,
+  setupMobileKeyboard,
+} from '../mobileKeyboard';
+
+const cleanups: Array<() => void> = [];
+
+function register(handler: (text: string, paneId: string | null) => void) {
+  const cleanup = setupMobileKeyboard(handler);
+  cleanups.push(cleanup);
+  return cleanup;
+}
+
+function insertText(text: string) {
+  const input = getMobileInput();
+  expect(input).not.toBeNull();
+  if (!input) return;
+  input.value = text;
+  input.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      data: text,
+      inputType: 'insertText',
+    }),
+  );
+}
+
+describe('mobileKeyboard handler ownership', () => {
+  beforeEach(() => {
+    cleanups.length = 0;
+    const input = getMobileInput();
+    if (input) {
+      input.value = '';
+      input.blur();
+    }
+  });
+
+  afterEach(() => {
+    for (let index = cleanups.length - 1; index >= 0; index -= 1) cleanups[index]();
+  });
+
+  it('keeps the newest handler when an older owner cleans up', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const cleanupFirst = register(first);
+    register(second);
+    focusKeyboardInput('%9');
+
+    cleanupFirst();
+    insertText('한');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledWith('한', '%9');
+  });
+
+  it('stops forwarding and blurs the input when the current owner cleans up', () => {
+    const handler = vi.fn();
+    const cleanup = register(handler);
+    focusKeyboardInput('%3');
+
+    cleanup();
+    insertText('x');
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(getMobileInput());
+  });
+
+  it('does not leak a previous pane target into the next owner', () => {
+    const cleanupFirst = register(vi.fn());
+    setKeyboardInputTarget('%3');
+    cleanupFirst();
+    const second = vi.fn();
+    register(second);
+
+    insertText('n');
+
+    expect(second).toHaveBeenCalledWith('n', null);
+  });
+});

--- a/packages/tmuxy-ui/src/utils/mobileKeyboard.ts
+++ b/packages/tmuxy-ui/src/utils/mobileKeyboard.ts
@@ -1,5 +1,5 @@
 /**
- * mobileKeyboard - Manages a hidden input that summons the virtual keyboard on touch devices.
+ * mobileKeyboard - Manages the hidden text input used by desktop IMEs and touch keyboards.
  *
  * Ownership:
  *  - keyboardActor calls setupMobileKeyboard() at startup to register a handler for
@@ -10,15 +10,19 @@
  * Key event routing:
  *  - Special keys (Backspace, Enter, arrows, Escape) fire reliable keydown events
  *    that bubble to window and are handled by keyboardActor's existing keydown listener.
- *  - Printable characters on mobile often only fire an `input` event (no reliable keydown).
- *    The `input` event handler here forwards them via the registered onText callback.
- *  - To avoid double-sending on browsers that fire both keydown AND input for a char,
- *    keyboardActor skips printable keydown events whose target is this input element.
+ *  - Printable characters and finalized IME compositions arrive through `input` or
+ *    `compositionend` events and are forwarded through the registered callback.
+ *  - keyboardActor skips printable keydowns from this input so text is sent once.
  */
 
 let input: HTMLInputElement | null = null;
 let activePaneId: string | null = null;
-let onText: ((text: string) => void) | null = null;
+let onText: ((text: string, paneId: string | null) => void) | null = null;
+let handlerOwner: symbol | null = null;
+let isComposing = false;
+let compositionPaneId: string | null = null;
+let suppressCommittedText: string | null = null;
+let clearSuppressionTimer: number | null = null;
 
 function ensureInput(): HTMLInputElement {
   if (!input) {
@@ -39,14 +43,46 @@ function ensureInput(): HTMLInputElement {
       left: '-100px',
     });
 
-    input.addEventListener('input', (e) => {
-      const ev = e as InputEvent;
-      // Only forward inserted text — special keys (Backspace, Enter) are handled
-      // by keyboardActor's window keydown listener. Skip during IME composition.
-      if (ev.inputType === 'insertText' && ev.data && !ev.isComposing && onText) {
-        onText(ev.data);
+    input.addEventListener('compositionstart', () => {
+      isComposing = true;
+      compositionPaneId = activePaneId;
+      suppressCommittedText = null;
+      if (clearSuppressionTimer !== null) {
+        window.clearTimeout(clearSuppressionTimer);
+        clearSuppressionTimer = null;
       }
-      // Always clear so the next keystroke starts from an empty field
+    });
+
+    input.addEventListener('compositionend', (event) => {
+      isComposing = false;
+      const targetPaneId = compositionPaneId ?? activePaneId;
+      compositionPaneId = null;
+      if (event.data && onText) {
+        onText(event.data, targetPaneId);
+        suppressCommittedText = event.data;
+        clearSuppressionTimer = window.setTimeout(() => {
+          suppressCommittedText = null;
+          clearSuppressionTimer = null;
+        }, 0);
+      }
+      if (input) input.value = '';
+    });
+
+    input.addEventListener('input', (event) => {
+      const inputEvent = event as InputEvent;
+      if (inputEvent.isComposing || isComposing) return;
+
+      if (inputEvent.inputType === 'insertText' && inputEvent.data && onText) {
+        if (inputEvent.data === suppressCommittedText) {
+          suppressCommittedText = null;
+          if (clearSuppressionTimer !== null) {
+            window.clearTimeout(clearSuppressionTimer);
+            clearSuppressionTimer = null;
+          }
+        } else {
+          onText(inputEvent.data, activePaneId);
+        }
+      }
       if (input) input.value = '';
     });
 
@@ -60,17 +96,54 @@ export function isTouchDevice(): boolean {
 }
 
 /** Called by keyboardActor at startup to register the character-forwarding handler. */
-export function setupMobileKeyboard(handler: (text: string) => void): () => void {
+export function setupMobileKeyboard(
+  handler: (text: string, paneId: string | null) => void,
+): () => void {
+  const owner = Symbol();
+  handlerOwner = owner;
   onText = handler;
   ensureInput();
   return () => {
+    if (handlerOwner !== owner) return;
+    handlerOwner = null;
     onText = null;
+    activePaneId = null;
+    isComposing = false;
+    compositionPaneId = null;
+    suppressCommittedText = null;
+    if (clearSuppressionTimer !== null) {
+      window.clearTimeout(clearSuppressionTimer);
+      clearSuppressionTimer = null;
+    }
+    if (input) {
+      input.value = '';
+      input.blur();
+    }
   };
 }
 
 /** Returns the hidden input element so keyboardActor can identify it via event.target. */
 export function getMobileInput(): HTMLInputElement | null {
   return input;
+}
+
+/** Updates the pane target without changing DOM focus. */
+export function setKeyboardInputTarget(paneId: string | null): void {
+  activePaneId = paneId;
+}
+
+function focusInput(paneId: string): void {
+  setKeyboardInputTarget(paneId);
+  const inp = ensureInput();
+  if (document.activeElement !== inp) {
+    inp.value = '';
+    inp.focus({ preventScroll: true });
+  }
+}
+
+/** Moves mouse or keyboard input to the hidden editable element. */
+export function focusKeyboardInput(paneId: string): void {
+  focusInput(paneId);
 }
 
 /**
@@ -88,8 +161,6 @@ export function focusMobileInput(paneId: string): void {
     inp.blur();
     activePaneId = null;
   } else {
-    activePaneId = paneId;
-    inp.value = '';
-    inp.focus();
+    focusInput(paneId);
   }
 }


### PR DESCRIPTION
## Summary
- route desktop IME and touch-keyboard text through one hidden editable input
- keep text, composition, and keyboard-actor focus on the same pane during header, floating-pane, and touch transitions
- preserve prefix, root, special-key, provisional-pane, and real-form-control behavior
- add regressions for composition de-duplication and pane-focus ordering

## Context
Follow-up to #7. The existing global composition-state handling suppresses composing keydowns, but desktop IME still lacks an editable target on initial load, and hidden-input focus can drift from the actor's focused pane around header, floating-pane, and touch transitions. This PR completes that path without reopening or closing #7.

## Testing
- `vitest run` — 36 files, 392 tests passed
- `tsc --noEmit`
- `prettier --check src`
- `eslint src` — 0 errors; 71 pre-existing warnings in unrelated files
- `vite build`

## Scope
This PR contains only repository source and regression-test changes. The machine-local service binding, UTF-8 locale, HTTP Basic Auth, and password-file configuration used for deployment testing live outside this repository. Merging this PR does not change or reproduce those settings.